### PR TITLE
Update belt_control.ipynb

### DIFF
--- a/belt_control.ipynb
+++ b/belt_control.ipynb
@@ -45,7 +45,7 @@
      "output_type": "stream",
      "text": [
       "Scanning for peripherals...\n",
-      "Device: [ 0], 5E00000D-5512-4000-825B-731000000000, WalkingPad, ['0000fe00-0000-1000-8000-00805f9b34fb']\n"
+      "Device: [ 0], 50:F1:4A:AD:23:85, WalkingPad, ['0000fe00-0000-1000-8000-00805f9b34fb']\n"
      ]
     }
    ],
@@ -91,7 +91,7 @@
    ],
    "source": [
     "ctler = Controller()\n",
-    "await ctler.run('5E00000D-5512-4000-825B-731000000000')  # set UUID from the scanning"
+    "await ctler.run('50:F1:4A:AD:23:85')  # set MAC address from the scanning"
    ]
   },
   {


### PR DESCRIPTION
When running the notebook, it didn't work for me because I was copying what looked like the UUID in the last column.  As it turns out, the id to type in is the first data column (after the counter), which in my case was all BTLE MAC addresses, not the long UUIDs from the example.  This causes confusion and is probably outdated?