### PR TITLE
Lets scan Scanner() for custom names and add them to Scanner().walkin…

### DIFF
--- a/belt_control.ipynb
+++ b/belt_control.ipynb
@@ -51,7 +51,8 @@
    ],
    "source": [
     "scanner = Scanner()\n",
-    "await scanner.scan()\n"
+    "await scanner.scan() #If the walkingpad is named 'walkingpad'\n",
+    "#await scanner.scan(customname='re') #Set a custom name for scanning. My pad is named 'RE'\n"
    ]
   },
   {
@@ -284,7 +285,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/ph4_walkingpad/pad.py
+++ b/ph4_walkingpad/pad.py
@@ -47,7 +47,7 @@ class Scanner:
     def get_bleak_kwargs():
         return Scanner.BLEAK_KWARGS if Scanner.is_darwin() else {}
 
-    async def scan(self, timeout=3.0):
+    async def scan(self, timeout=3.0, customname='walkingpad'):
         kwargs = Scanner.get_bleak_kwargs()
         logger.info("Scanning for peripherals...")
         logger.debug("Scanning kwargs: %s" % (kwargs,))
@@ -64,7 +64,7 @@ class Scanner:
             self.devices_dict[dev[i].address].append(dev[i].metadata["uuids"])
             self.devices_list.append(dev[i].address)
 
-            if 'walkingpad' in dev[i].name.lower():
+            if customname in dev[i].name.lower():
                 self.walking_belt_candidates.append(dev[i])
 
 


### PR DESCRIPTION
I add an option to scan for differently named walkingpads.
My King smits walkingpad R1 is compatible with the library, but identifies as 'RE' in bluetooth scans